### PR TITLE
Handle larger files and progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-filebrowser",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "license": "MIT",
   "description": "Angular filebrowser backed by git repository in the browser",
   "homepage": "https://github.com/fintechneo/angular-git-filebrowser",

--- a/src/app/repository/credentials.service.ts
+++ b/src/app/repository/credentials.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class CredientialsService {
+    username: string;
+    password: string;
+}

--- a/src/app/repository/credentials.service.ts
+++ b/src/app/repository/credentials.service.ts
@@ -4,4 +4,25 @@ import { Injectable } from '@angular/core';
 export class CredientialsService {
     username: string;
     password: string;
+    gitname = 'Test';
+    gitemail = 'test@example.com';
+    proxyhost = 'http://localhost:4200';
+
+    constructor() {
+        try {
+            const storedCredentials: CredientialsService =
+                JSON.parse(sessionStorage.getItem('filebrowsersessioncredentials'));
+            this.username = storedCredentials.username;
+            this.password = storedCredentials.password;
+            this.gitemail = storedCredentials.gitemail;
+            this.gitname = storedCredentials.gitname;
+            this.proxyhost = storedCredentials.proxyhost;
+        } catch (e) {
+
+        }
+    }
+
+    storeCredentialsInSessionStorage() {
+        sessionStorage.setItem('filebrowsersessioncredentials', JSON.stringify(this));
+    }
 }

--- a/src/app/repository/repository.module.ts
+++ b/src/app/repository/repository.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { MatSidenavModule, MatListModule,
     MatInputModule, MatCardModule, MatToolbarModule,
-        MatIconModule, MatButtonModule, MatPaginatorModule, MatTableModule } from '@angular/material';
+        MatIconModule, MatButtonModule, MatPaginatorModule, MatTableModule, MatCheckboxModule } from '@angular/material';
 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -25,6 +25,7 @@ import { CredientialsService } from './credentials.service';
         MatIconModule,
         MatInputModule,
         MatListModule,
+        MatCheckboxModule,
         MatTableModule,
         MatPaginatorModule,
         MatToolbarModule,

--- a/src/app/repository/repository.module.ts
+++ b/src/app/repository/repository.module.ts
@@ -13,6 +13,7 @@ import { FileBrowserModule } from '../../lib/filebrowser.module';
 import { LayoutHelperModule } from '../../lib/layout/layouthelper.module';
 import { SelectRepositoryComponent } from './selectrepository.component';
 import { SingleDirectoryViewComponent } from './singledirectoryview.component';
+import { CredientialsService } from './credentials.service';
 
 @NgModule({
     imports: [
@@ -64,6 +65,9 @@ import { SingleDirectoryViewComponent } from './singledirectoryview.component';
         RepositoryBrowserComponent,
         LogComponent,
         RepositoryComponent
+    ],
+    providers: [
+        CredientialsService
     ]
 })
 export class RepositoryModule {

--- a/src/app/repository/repository.service.ts
+++ b/src/app/repository/repository.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
 
 import { Observable, AsyncSubject } from 'rxjs';
 import { mergeMap, tap } from 'rxjs/operators';
@@ -22,24 +22,30 @@ export class RepositoryService implements OnDestroy {
         private filebrowserservice: FileBrowserService,
         public snackBar: MatSnackBar,
         public route: ActivatedRoute,
-        private credentialsService: CredientialsService,
-        private http: HttpClient
+        credentialsService: CredientialsService
     ) {
+        credentialsService.storeCredentialsInSessionStorage();
         this.gitbackendservice = this.filebrowserservice as GitBackendService;
         this.gitbackendservice.convertUploadsToLFSPointer = true;
         const basicAuthHeader = 'Basic ' + btoa(`${credentialsService.username}:${credentialsService.password}`);
+        this.gitbackendservice.proxyHost = credentialsService.proxyhost;
         this.gitbackendservice.gitLFSAuthorizationHeaderValue = basicAuthHeader;
-        this.gitbackendservice.setHeaders(
-            new HttpHeaders(
-                {'Authorization': basicAuthHeader
-            }
-        ));
+
         GitProgressSnackbarComponent.activate(snackBar, this.gitbackendservice);
 
         this.route.params.pipe(
             tap(params => this.workdir = params.repository),
             mergeMap(params => this.gitbackendservice.mount(params.repository)),
             mergeMap(isGitRepo => {
+                this.gitbackendservice.setHeaders(
+                    new HttpHeaders(
+                        {'Authorization': basicAuthHeader
+                    }
+                ));
+                this.gitbackendservice.setUser(
+                    credentialsService.gitname, credentialsService.gitemail
+                );
+
                 if (isGitRepo) {
                     return this.synchronizeChanges();
                 } else {

--- a/src/app/repository/repository.service.ts
+++ b/src/app/repository/repository.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material';
 import { ActivatedRoute } from '@angular/router';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { Observable, AsyncSubject } from 'rxjs';
 import { mergeMap, tap } from 'rxjs/operators';
 import { GitBackendService, FileBrowserService } from '../../lib/filebrowser.module';
 import { GitProgressSnackbarComponent } from '../../lib/gitbackend/gitprogresssnackbar.component';
+import { CredientialsService } from './credentials.service';
 
 @Injectable()
 export class RepositoryService implements OnDestroy {
@@ -21,10 +22,18 @@ export class RepositoryService implements OnDestroy {
         private filebrowserservice: FileBrowserService,
         public snackBar: MatSnackBar,
         public route: ActivatedRoute,
+        private credentialsService: CredientialsService,
         private http: HttpClient
     ) {
         this.gitbackendservice = this.filebrowserservice as GitBackendService;
         this.gitbackendservice.convertUploadsToLFSPointer = true;
+        const basicAuthHeader = 'Basic ' + btoa(`${credentialsService.username}:${credentialsService.password}`);
+        this.gitbackendservice.gitLFSAuthorizationHeaderValue = basicAuthHeader;
+        this.gitbackendservice.setHeaders(
+            new HttpHeaders(
+                {'Authorization': basicAuthHeader
+            }
+        ));
         GitProgressSnackbarComponent.activate(snackBar, this.gitbackendservice);
 
         this.route.params.pipe(

--- a/src/app/repository/repositorybrowser.component.html
+++ b/src/app/repository/repositorybrowser.component.html
@@ -1,5 +1,6 @@
 <mat-card>
-    <mat-card-content>            
+    <mat-card-content>       
+        <mat-checkbox [(ngModel)]="gitbackendservice.convertUploadsToLFSPointer">Use LFS for uploads</mat-checkbox>          
         <app-filebrowser 
             [fileInfoFilter]="hideFileIfStartingWithDotFilter"
             [fileActionsHandler]="fileActionsHandler"

--- a/src/app/repository/repositorybrowser.component.ts
+++ b/src/app/repository/repositorybrowser.component.ts
@@ -6,7 +6,7 @@ import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
 import { RepositoryService } from './repository.service';
 import { FileActionsHandler } from '../../lib/fileactionshandler.interface';
-import { FileBrowserService, FileInfo } from '../../lib/filebrowser.module';
+import { FileBrowserService, FileInfo, GitBackendService } from '../../lib/filebrowser.module';
 import { FilesChangeEvent } from '../../lib/fileschangeevent.class';
 
 @Component({
@@ -15,6 +15,7 @@ import { FilesChangeEvent } from '../../lib/fileschangeevent.class';
 export class RepositoryBrowserComponent {
 
     fileActionsHandler: FileActionsHandler;
+    gitbackendservice: GitBackendService;
 
     hideFileIfStartingWithDotFilter = (fileInfo: FileInfo): boolean => {
         return fileInfo.name.indexOf('.') === 0 ? false : true;
@@ -27,6 +28,8 @@ export class RepositoryBrowserComponent {
         private repositoryservice: RepositoryService,
         http: HttpClient
     ) {
+        this.gitbackendservice = filebrowserservice as GitBackendService;
+
         this.fileActionsHandler = new class implements FileActionsHandler {
 
             editFile(fileInfo: FileInfo): boolean {

--- a/src/app/repository/selectrepository.component.html
+++ b/src/app/repository/selectrepository.component.html
@@ -8,6 +8,12 @@
             <mat-form-field style="width: 300px; margin-right: 5px">
                 <input matInput [(ngModel)]="gitrepositoryurl" placeholder="Git repository URL"  />
             </mat-form-field>
+            <mat-form-field>
+                <input matInput [(ngModel)]="credentialsService.username" type="text" placeholder="Username" />                
+            </mat-form-field>
+            <mat-form-field>
+                <input matInput [(ngModel)]="credentialsService.password" type="password" placeholder="Password" />
+            </mat-form-field>
         </div>        
     </mat-card-content>
     <mat-card-actions>

--- a/src/app/repository/selectrepository.component.html
+++ b/src/app/repository/selectrepository.component.html
@@ -14,6 +14,15 @@
             <mat-form-field>
                 <input matInput [(ngModel)]="credentialsService.password" type="password" placeholder="Password" />
             </mat-form-field>
+            <mat-form-field style="width: 300px; margin-right: 5px">
+                <input matInput [(ngModel)]="credentialsService.proxyhost" placeholder="Proxy host"  />
+            </mat-form-field>
+            <mat-form-field>
+                <input matInput [(ngModel)]="credentialsService.gitname" type="text" placeholder="Git commit name" />                
+            </mat-form-field>
+            <mat-form-field>
+                <input matInput [(ngModel)]="credentialsService.gitemail" type="text" placeholder="Git commit email" />
+            </mat-form-field>
         </div>        
     </mat-card-content>
     <mat-card-actions>

--- a/src/app/repository/selectrepository.component.ts
+++ b/src/app/repository/selectrepository.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
+import { CredientialsService } from './credentials.service';
 
 @Component({
     templateUrl: 'selectrepository.component.html'
@@ -9,7 +10,8 @@ export class SelectRepositoryComponent {
     gitrepositoryurl = 'https://github.com/fintechneo/browsergittestdata.git';
 
     constructor(
-        private router: Router
+        private router: Router,
+        public credentialsService: CredientialsService
     ) {
 
     }

--- a/src/lib/gitbackend/gitbackend.service.ts
+++ b/src/lib/gitbackend/gitbackend.service.ts
@@ -621,7 +621,6 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
             console.log('Git backend service terminated');
             this.mountdir = null;
             this.repositoryOpen = false;
-            this.currentStatus.complete();
         }
     }
 

--- a/src/lib/gitbackend/gitbackend.service.ts
+++ b/src/lib/gitbackend/gitbackend.service.ts
@@ -379,6 +379,9 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
         ).pipe(
             mergeMap((url: string) => {
                 if (url.indexOf('version ') === 0) {
+                    const lfsPointerLines = url.split('\n');
+                    const filesize = parseInt(lfsPointerLines[2].substring('size '.length), 10);
+
                     return this.getLFSDownloadURL(url)
                         .pipe(
                             mergeMap((downloadurl: string) => {
@@ -391,7 +394,10 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
                                     .pipe(
                                         map((event: HttpEvent<any>) => {
                                             if (event.type === HttpEventType.DownloadProgress) {
-                                                this.currentStatus.next(`Downloading ${formatBytes(event.loaded)}`);
+                                                const percentDone = Math.round(100 * event.loaded / filesize);
+                                                this.currentStatus.next(
+                                                    `Downloading ${formatBytes(event.loaded, 2)} ( ${percentDone} %)`
+                                                );
                                             } else if (event.type === HttpEventType.Response) {
                                                 return event.body;
                                             }
@@ -794,7 +800,7 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
                             tap((event: HttpEvent<any>) => {
                                 if (event.type === HttpEventType.UploadProgress) {
                                     const percentDone = Math.round(100 * event.loaded / event.total);
-                                    this.currentStatus.next(`Uploading ${formatBytes(event.loaded)} ( ${percentDone} % )`);
+                                    this.currentStatus.next(`Uploading ${formatBytes(event.loaded, 2)} ( ${percentDone} % )`);
                                 } else if (event.type === HttpEventType.Response) {
                                     return event.body;
                                 }

--- a/src/lib/gitbackend/gitprogresssnackbar.component.ts
+++ b/src/lib/gitbackend/gitprogresssnackbar.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { FileBrowserService } from '../filebrowser.service';
 import { GitBackendService } from './gitbackend.service';
 import { MatSnackBarRef, MatSnackBar } from '@angular/material';
 import { Subject } from 'rxjs';


### PR DESCRIPTION
This PR is fixing the problem when uploading files larger than about 130 MB. It also adds progress on upload/download. Upload progress does not work however when using a service worker, which is because of the service worker not forwarding progress events while sending data.

Also there are some additions to the test app UI, with input fields for username/password, proxy and git commit user/email. Also reinserted the toggle for switching on/off LFS uploads.