### PR TITLE
git-conflicts: merge tool for resolving JSON conflicts

### DIFF
--- a/ngmakelib-conf.js
+++ b/ngmakelib-conf.js
@@ -15,7 +15,9 @@ ngMakeLib.addAssets([
 if(process.argv[process.argv.length-1] === '--watch') {
     ngMakeLib.watch();
 } else {
-    ngMakeLib.packageJSONConfig.dependencies = {};
+    ngMakeLib.packageJSONConfig.dependencies = {
+        "deep-diff": "1.0.2"
+    };
     ngMakeLib.packageJSONConfig.devDependencies = {};
     ngMakeLib.build();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3085,6 +3085,11 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-diff": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
+      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg=="
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-filebrowser",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "license": "MIT",
   "description": "Angular filebrowser backed by git repository in the browser",
   "homepage": "https://github.com/fintechneo/angular-git-filebrowser",
@@ -32,6 +32,7 @@
     "@angular/platform-browser": "^7.1.3",
     "@angular/platform-browser-dynamic": "^7.1.3",
     "@angular/router": "^7.1.3",
+    "deep-diff": "^1.0.2",
     "rxjs": "^6.3.3",
     "rxjs-compat": "^6.2.2",
     "tsickle": "^0.34.0",

--- a/src/lib/gitbackend/gitbackend.service.ts
+++ b/src/lib/gitbackend/gitbackend.service.ts
@@ -4,7 +4,7 @@ import { FileBrowserService } from '../filebrowser.service';
 import { FileInfo } from '../filebrowser.service';
 import { mergeMap, map, tap, take, last } from 'rxjs/operators';
 import { HttpHeaders, HttpClient, HttpEventType, HttpEvent, HttpRequest } from '@angular/common/http';
-import { ConflictPick, hasConflicts, getConflictVersion } from './resolveconflict';
+import { ConflictPick, hasConflicts, getConflictVersion, getJSONConflictVersion } from './resolveconflict';
 
 /*
  * These are used in the worker - but we declare them here so that typescript doesn't complain
@@ -443,7 +443,9 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
             .pipe(
                 mergeMap(contents => {
                     if (hasConflicts(contents)) {
-                        const resolved = getConflictVersion(contents, chosenConclictSide);
+                        const resolved = filename.endsWith('.json') ? 
+                            getJSONConflictVersion(contents, chosenConclictSide) :
+                            getConflictVersion(contents, chosenConclictSide);
                         return this.saveTextFile(filename, resolved)
                             .pipe(map(() => resolved));
                     } else {

--- a/src/lib/gitbackend/resolveconflict.spec.ts
+++ b/src/lib/gitbackend/resolveconflict.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictPick, resolveNextConflict, hasConflicts } from './resolveconflict';
+import { ConflictPick, resolveNextConflict, hasConflicts, getConflictVersion, getJSONConflictVersion } from './resolveconflict';
 
 const conflictJSONstring = `{
 "id": null,
@@ -50,5 +50,34 @@ describe('ResolveGitConflictTest', () => {
         expect(hasConflicts(minestring)).toBeFalsy();
         expect(hasConflicts(oldstring)).toBeFalsy();
         expect(hasConflicts(yoursstring)).toBeFalsy();
+    });
+
+    it('should resolve JSON conflict', () => {
+        console.log('Testing resolving diff3 conflicts with JSON merger');
+        
+        const mine = JSON.parse(getJSONConflictVersion(conflictJSONstring, ConflictPick.MINE));
+        const old = JSON.parse(getJSONConflictVersion(conflictJSONstring, ConflictPick.OLD));
+        const yours = JSON.parse(getJSONConflictVersion(conflictJSONstring, ConflictPick.YOURS));
+
+        expect(
+            mine.title
+        ).toEqual('Test test 7060 - changed title');
+        expect(
+            mine.locationName
+        ).toEqual('changed location');
+
+        expect(
+            yours.title
+        ).toEqual('Test test 7060 - changed title');
+        expect(
+            yours.locationName
+        ).toEqual('changed location');
+
+        expect(
+            old.locationName
+        ).toEqual('wwewe derefetet');
+        expect(
+            old.title
+        ).toEqual('Test test 7060');        
     });
 });

--- a/src/lib/gitbackend/resolveconflict.ts
+++ b/src/lib/gitbackend/resolveconflict.ts
@@ -1,7 +1,33 @@
+import { diff, applyChange} from 'deep-diff';
+
 export enum ConflictPick {
     MINE,
     OLD,
     YOURS
+}
+
+export function getJSONConflictVersion(text, pick) {
+    const originalText = getConflictVersion(text, 1);
+    if(pick===1) {        
+        return originalText;
+    }
+    
+    const original = JSON.parse(originalText);
+    const mine = JSON.parse(getConflictVersion(text, 0));
+    const yours = JSON.parse(getConflictVersion(text, 2));
+
+    const minePatch = diff(original, mine);
+    const yourPatch = diff(original, yours);
+
+    
+    if(pick===0) {
+        yourPatch.forEach(change => applyChange(original,null, change));
+        minePatch.forEach(change => applyChange(original,null, change));
+    } else if(pick === 2) {
+        minePatch.forEach(change => applyChange(original,null, change));
+        yourPatch.forEach(change => applyChange(original,null, change));
+    }
+    return JSON.stringify(original, null, 1);
 }
 
 export function getConflictVersion(text: string, pick: ConflictPick): string {


### PR DESCRIPTION
If using `quickResolveConflict` from `GitBackendService` to resolve conflicts, files with name ending with `.json` will be handled with javascript object diff tool ( https://github.com/flitbit/diff ) by first applying the changes from the side with least priority and then applying the changes from the side with most priority.

