### PR TITLE
Fix rmdir to handle dot files in folder.

### DIFF
--- a/src/lib/gitbackend/foldertest.spec.ts
+++ b/src/lib/gitbackend/foldertest.spec.ts
@@ -1,0 +1,56 @@
+import { GitBackendService } from './gitbackend.service';
+import { map, take } from 'rxjs/operators';
+
+
+describe('FolderOp', () => {
+    let gitbackendservice: GitBackendService;
+    beforeAll(async () => {
+        gitbackendservice = new GitBackendService(null);
+        gitbackendservice.syncLocalFSDisabled = true;
+        await gitbackendservice.mount('testworkdir')
+            .pipe(take(1))
+            .toPromise();
+        console.log('mount done');
+    });
+
+
+    it('create a folder and file. then delete folder ', async () => {
+
+        await gitbackendservice.mkdir('xyz').pipe(take(1)).toPromise();
+        await gitbackendservice.changedir('xyz').pipe(take(1)).toPromise();
+        await gitbackendservice.saveTextFile('test.txt', 'abcdefg').pipe(take(1)).toPromise();
+        await gitbackendservice.saveTextFile('.hidden', 'abcdefg').pipe(take(1)).toPromise();
+
+        const dircontents1 = await gitbackendservice.readdir()
+            .pipe(
+                map(
+                    list => list.filter(d => d.fullpath === '/testworkdir/xyz/test.txt')
+                ),
+                take(1)
+            ).toPromise();
+
+        expect(dircontents1.length).toBe(1);
+        console.log('rmdir finished');
+
+        await gitbackendservice.changedir('..').pipe(take(1)).toPromise()
+        
+        await gitbackendservice.rmdir('xyz').pipe(take(1)).toPromise();
+
+        const dircontents2 = await gitbackendservice.readdir()
+            .pipe(
+                take(1)
+            ).toPromise();
+
+
+        expect(dircontents2.filter(d => d.fullpath === '/testworkdir/xyz/test.txt').length).toBe(0);
+        expect(dircontents2.filter(d => d.fullpath === '/testworkdir/xyz').length).toBe(0);
+        console.log('rmdir finished');
+
+    });
+
+
+
+    afterAll(() => {
+        gitbackendservice.unmount();
+    });
+});

--- a/src/lib/gitbackend/gitbackend.service.ts
+++ b/src/lib/gitbackend/gitbackend.service.ts
@@ -551,7 +551,7 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
             }
             const recursedir = (path) =>
                 FS.readdir(path)
-                    .filter((f: string) => !f.startsWith('.'))
+                    .filter((f: string) =>  !(f=== '.'  || f === '..' ))
                     .forEach((f: string) => {
                         const deletepath = path + '/' + f;
                         console.log('Deleting', deletepath);


### PR DESCRIPTION
- was ignoring files starting with '.'
- now delete all files apart from '.'   or '..'  
- Added unit test.