### PR TITLE
fix(pwa): upload progress indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-filebrowser",
-  "version": "0.0.51",
+  "version": "0.0.53",
   "license": "MIT",
   "description": "Angular filebrowser backed by git repository in the browser",
   "homepage": "https://github.com/fintechneo/angular-git-filebrowser",

--- a/src/lib/gitbackend/gitbackend.service.ts
+++ b/src/lib/gitbackend/gitbackend.service.ts
@@ -889,7 +889,8 @@ export class GitBackendService extends FileBrowserService implements OnDestroy {
                     const uploadobj = ret.objects[0].actions.upload;
                     const verifyobj = ret.objects[0].actions.verify;
 
-                    const headers = new HttpHeaders(uploadobj.header);
+                    let headers = new HttpHeaders(uploadobj.header);
+                    headers = headers.append('ngsw-bypass', 'true');
 
                     let url = uploadobj.href;
 


### PR DESCRIPTION
bypass serviceworker on fileupload
using feature described in
https://angular.io/guide/service-worker-devops#bypassing-the-service-worker