### PR TITLE
feat(filebrowser): custom logic on fileupload

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -26,7 +26,7 @@ describe('angular-filebrowser App', () => {
     page.navigateTo();
     gitserver.addLogExpectation('GET /testorganization/testrepo/info/refs?service=git-upload-pack');
     await page.setGitRepositoryUrlInputAndClone();
-    await page.deactivateLFSAndUploadFile('README.md');
+    await page.uploadFileWithoutLFS('README.md');
     expect(gitserver.areLogExpectationsMet()).toBe(true);
 
     const gitlog = gitserver.gitLog('testorganization', 'testrepo');
@@ -38,7 +38,7 @@ describe('angular-filebrowser App', () => {
     page.navigateTo();
     gitserver.addLogExpectation('GET /testorganization/testrepo/info/refs?service=git-upload-pack');
     await page.setUserAndPull();
-    await page.deactivateLFSAndUploadFile('angular.json');
+    await page.uploadFileWithoutLFS('angular.json');
     expect(gitserver.areLogExpectationsMet()).toBe(true);
 
     const gitlog = gitserver.gitLog('testorganization', 'testrepo');

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -30,11 +30,7 @@ export class AppPage {
     await browser.wait(async () => (await browser.getCurrentUrl()).indexOf('/browse') > 0, 10000);    
   }
 
-  async deactivateLFSAndUploadFile(filename: string) {
-    const lfsCheckbox = element(by.cssContainingText('mat-checkbox', 'Use LFS for uploads'));
-    await browser.wait(() => lfsCheckbox.isPresent(), 2000);
-    await lfsCheckbox.click();
-
+  async uploadFileWithoutLFS(filename: string) {
     await new Promise(r => setTimeout(r, 1000));
 
     const fileInputElement = element(by.css('input[type=file]'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-filebrowser",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "license": "MIT",
   "description": "Angular filebrowser backed by git repository in the browser",
   "homepage": "https://github.com/fintechneo/angular-git-filebrowser",

--- a/src/app/repository/repository.module.ts
+++ b/src/app/repository/repository.module.ts
@@ -14,6 +14,7 @@ import { LayoutHelperModule } from '../../lib/layout/layouthelper.module';
 import { SelectRepositoryComponent } from './selectrepository.component';
 import { SingleDirectoryViewComponent } from './singledirectoryview.component';
 import { CredientialsService } from './credentials.service';
+import { UploadUsingLFSDialogComponent } from './uploadusinglfsdialog.component';
 
 @NgModule({
     imports: [
@@ -65,7 +66,11 @@ import { CredientialsService } from './credentials.service';
         SingleDirectoryViewComponent,
         RepositoryBrowserComponent,
         LogComponent,
-        RepositoryComponent
+        RepositoryComponent,
+        UploadUsingLFSDialogComponent
+    ],
+    entryComponents: [
+        UploadUsingLFSDialogComponent
     ],
     providers: [
         CredientialsService

--- a/src/app/repository/repositorybrowser.component.html
+++ b/src/app/repository/repositorybrowser.component.html
@@ -1,6 +1,5 @@
 <mat-card>
-    <mat-card-content>       
-        <mat-checkbox [(ngModel)]="gitbackendservice.convertUploadsToLFSPointer">Use LFS for uploads</mat-checkbox>          
+    <mat-card-content>
         <app-filebrowser 
             [fileInfoFilter]="hideFileIfStartingWithDotFilter"
             [fileActionsHandler]="fileActionsHandler"

--- a/src/app/repository/uploadusinglfsdialog.component.ts
+++ b/src/app/repository/uploadusinglfsdialog.component.ts
@@ -1,0 +1,28 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+
+@Component({
+    template: `
+    <p>File {{fileInfo.name}} was not detected as a text file (type is {{fileInfo.type}}).</p>
+    <p>Filesize is {{fileInfo.size}}. While not using LFS will make the file available offline,
+    it is recommended to use LFS for larger binary uploads so that they don't take up space in the git repository.
+    </p>
+    <button mat-button (click)="closeUsingLFS()">Use LFS (recommended)</button>
+    <button mat-button (click)="closeNotUsingLFS()">Don't use LFS</button>
+    `
+})
+export class UploadUsingLFSDialogComponent {
+    constructor(
+        private dialogRef: MatDialogRef<UploadUsingLFSDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public fileInfo: File) {
+
+    }
+
+    closeUsingLFS() {
+        this.dialogRef.close(false);
+    }
+
+    closeNotUsingLFS() {
+        this.dialogRef.close(true);
+    }
+}

--- a/src/lib/fileactionshandler.interface.ts
+++ b/src/lib/fileactionshandler.interface.ts
@@ -1,4 +1,5 @@
 import { FileInfo } from './filebrowser.service';
+import { Observable } from 'rxjs';
 
 export interface FileActionsHandler {
     /**
@@ -19,4 +20,13 @@ export interface FileActionsHandler {
      * @returns true if default open action should be run
      */
     openFile(fileInfo: FileInfo): boolean;
+
+    /**
+     * custom logic for handling uploading of a file
+     * will be invoked before every file upload
+     * use e.g. to decide if LFS should be used
+     * 
+     * @returns observable of boolean which is true if upload should proceed, or false if it should be cancelled
+     */
+    beforeUpload(fileInfo: File): Observable<boolean>;
 }


### PR DESCRIPTION
The purpose of this addition is to be able to better resolve when to use LFS. An example resolver is automatically disabling LFS if a text file is detected, while if the file is binary and large (more than 1MB), LFS is always used. If the binary is less than 1MB a prompt is displayed asking the user to decide. The consuming application is free to customize the logic by implementing the `beforeUpload` method on the `FileActionsHandler` interface.

- add handler on fileuploads to support custom logic.
- example by configuring the use of LFS based on uploaded file type